### PR TITLE
Fix assert condition in master & slave for RTU connection

### DIFF
--- a/mbrtu_mstr.c
+++ b/mbrtu_mstr.c
@@ -92,7 +92,7 @@ static void set_termois(int fd)
 	struct termios2 tio;
 
 	ret = ioctl(fd, TCGETS2, &tio);
-	assert(ret > 0);
+	assert(ret >= 0);
 	
 	tio.c_iflag &= ~(ISTRIP|IUCLC|IGNCR|ICRNL|INLCR|ICANON|IXON|IXOFF|PARMRK);
 	tio.c_iflag |= (IGNBRK|IGNPAR);
@@ -110,7 +110,7 @@ static void set_termois(int fd)
 	tio.c_ospeed = BAUDRATE;
 	tio.c_ispeed = BAUDRATE;
 	ret = ioctl(fd, TCSETS2, &tio);
-	assert(ret > 0);
+	assert(ret >= 0);
 	
 	mb_printf("Setting termios: ospeed %d ispeed %d\n", tio.c_ospeed, tio.c_ispeed);
 }

--- a/mbrtu_slv.c
+++ b/mbrtu_slv.c
@@ -132,7 +132,7 @@ static int set_termois(int fd)
 	struct termios2 tio;
 
 	ret = ioctl(fd, TCGETS2, &tio);
-	assert(ret > 0);
+	assert(ret >= 0);
 	
 	tio.c_iflag &= ~(ISTRIP|IUCLC|IGNCR|ICRNL|INLCR|ICANON|IXON|IXOFF|IXANY|PARMRK);
 	tio.c_iflag |= (IGNBRK|IGNPAR);
@@ -150,7 +150,7 @@ static int set_termois(int fd)
 	tio.c_ospeed = BAUDRATE;
 	tio.c_ispeed = BAUDRATE;
 	ret = ioctl(fd, TCSETS2, &tio);
-	assert(ret > 0);
+	assert(ret >= 0);
 	
 	mb_printf("Setting termios: ospeed %d ispeed %d\n", tio.c_ospeed, tio.c_ispeed);
 	


### PR DESCRIPTION
Fix assert condition used after ioctl call in the on RTU master and slave. 
From ioctl man: "Usually,  on success zero is returned.  A few ioctl() operations use the return value as an output parameter and return a nonnegative value on success.  On error, -1 is returned, and errno is set to indicate the error."